### PR TITLE
fix: correct OAuth redirect URL generation

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -11,3 +11,4 @@
 - Добавлены маршруты совместимости для OAuth (`/auth/authorisationurl`, `/thirdparty/:provider/redirect_url`) и health-check `/healthz`.
 - В `AuthProvider` вынесен базовый URL API в переменную `NEXT_PUBLIC_API_BASE_URL`.
 - Настроен `vite.config.ts` для поддержки `NEXT_PUBLIC_*` переменных.
+- Исправлено формирование OAuth URL: теперь используется `/thirdparty/authorisationurl` с передачей `redirectURIOnProviderDashboard`, что корректно перенаправляет пользователя после входа через Google.

--- a/src/worker/auth.ts
+++ b/src/worker/auth.ts
@@ -3,8 +3,18 @@ import { getCookie } from 'hono/cookie';
 
 export const HUNKO_SESSION_TOKEN_COOKIE_NAME = 'hunko_session_token';
 
-export async function getOAuthRedirectUrl(provider: string, opts: { apiUrl: string; apiKey: string; }) {
-  const res = await fetch(`${opts.apiUrl}/oauth/${provider}/redirect_url`, {
+export async function getOAuthRedirectUrl(
+  provider: string,
+  opts: { apiUrl: string; apiKey: string; dashboardUrl: string }
+) {
+  const url = new URL(`${opts.apiUrl}/thirdparty/authorisationurl`);
+  url.searchParams.set('thirdPartyId', provider);
+  url.searchParams.set(
+    'redirectURIOnProviderDashboard',
+    `${opts.dashboardUrl}/auth/callback`
+  );
+
+  const res = await fetch(url.toString(), {
     headers: { 'x-api-key': opts.apiKey },
   });
   if (!res.ok) throw new Error('Failed to get redirect URL');

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -86,6 +86,7 @@ app.get('/auth/authorisationurl', async (c) => {
   const redirectUrl = await getOAuthRedirectUrl(provider, {
     apiUrl: c.env.HUNKO_USERS_SERVICE_API_URL,
     apiKey: c.env.HUNKO_USERS_SERVICE_API_KEY,
+    dashboardUrl: new URL(c.req.url).origin,
   });
   return c.json({ redirectUrl }, 200);
 });
@@ -95,6 +96,7 @@ app.get('/thirdparty/:provider/redirect_url', async (c) => {
   const redirectUrl = await getOAuthRedirectUrl(provider, {
     apiUrl: c.env.HUNKO_USERS_SERVICE_API_URL,
     apiKey: c.env.HUNKO_USERS_SERVICE_API_KEY,
+    dashboardUrl: new URL(c.req.url).origin,
   });
   return c.json({ redirectUrl }, 200);
 });
@@ -103,6 +105,7 @@ app.get('/api/oauth/google/redirect_url', async (c) => {
   const redirectUrl = await getOAuthRedirectUrl('google', {
     apiUrl: c.env.HUNKO_USERS_SERVICE_API_URL,
     apiKey: c.env.HUNKO_USERS_SERVICE_API_KEY,
+    dashboardUrl: new URL(c.req.url).origin,
   });
 
   return c.json({ redirectUrl }, 200);


### PR DESCRIPTION
## Summary
- build OAuth redirect using `/thirdparty/authorisationurl` with dashboard callback
- pass dashboard origin when requesting provider redirect URL
- log update about new OAuth URL formation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68989bfea9208332adc93283f3cca435