### PR TITLE
feat: improve oauth redirect and add password auth

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -12,3 +12,5 @@
 - В `AuthProvider` вынесен базовый URL API в переменную `NEXT_PUBLIC_API_BASE_URL`.
 - Настроен `vite.config.ts` для поддержки `NEXT_PUBLIC_*` переменных.
 - Исправлено формирование OAuth URL: теперь используется `/thirdparty/authorisationurl` с передачей `redirectURIOnProviderDashboard`, что корректно перенаправляет пользователя после входа через Google.
+- Добавлен фолбэк для `getOAuthRedirectUrl` с поддержкой параметра `redirect_url` и внутренних адресов Hanko, что убирает ошибку `Invalid URL string`.
+- Реализована авторизация по email и паролю, добавлена страница регистрации в том же дизайне, что и страница входа.

--- a/src/react-app/App.tsx
+++ b/src/react-app/App.tsx
@@ -6,6 +6,7 @@ import Dashboard from "@/react-app/pages/Dashboard";
 import Pricing from "@/react-app/pages/Pricing";
 import Earnings from "@/react-app/pages/Earnings";
 import Admin from "@/react-app/pages/Admin";
+import Register from "@/react-app/pages/Register";
 
 export default function App() {
   return (
@@ -13,6 +14,8 @@ export default function App() {
       <Router>
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/login" element={<HomePage />} />
+          <Route path="/register" element={<Register />} />
           <Route path="/auth/callback" element={<AuthCallback />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/pricing" element={<Pricing />} />

--- a/src/react-app/components/LoginScreen.tsx
+++ b/src/react-app/components/LoginScreen.tsx
@@ -1,8 +1,16 @@
 import { useAuth } from '@/auth';
 import { Shield, Lock, Globe, Zap } from 'lucide-react';
+import { useState } from 'react';
 
 export default function LoginScreen() {
-  const { redirectToLogin, isFetching } = useAuth();
+  const { redirectToLogin, loginWithPassword, isFetching } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handlePasswordLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await loginWithPassword(email, password);
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
@@ -31,6 +39,32 @@ export default function LoginScreen() {
             </div>
           </div>
 
+          <form onSubmit={handlePasswordLogin} className="space-y-4 mb-6">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
+              className="w-full px-4 py-3 rounded-lg bg-slate-900/50 border border-slate-700 text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Пароль"
+              className="w-full px-4 py-3 rounded-lg bg-slate-900/50 border border-slate-700 text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+            <button
+              type="submit"
+              disabled={isFetching}
+              className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-xl transition-colors"
+            >
+              {isFetching ? 'Загрузка...' : 'Войти'}
+            </button>
+          </form>
+
           <button
             onClick={redirectToLogin}
             disabled={isFetching}
@@ -41,6 +75,10 @@ export default function LoginScreen() {
 
           <p className="text-slate-500 text-xs text-center mt-4">
             Нажимая "Войти", вы соглашаетесь с условиями использования
+          </p>
+
+          <p className="text-slate-400 text-center mt-4">
+            Нет аккаунта? <a href="/register" className="text-blue-500 hover:underline">Зарегистрируйтесь</a>
           </p>
         </div>
       </div>

--- a/src/react-app/pages/Register.tsx
+++ b/src/react-app/pages/Register.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useAuth } from '@/auth';
+import { Shield } from 'lucide-react';
+
+export default function Register() {
+  const { register, isFetching } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password !== confirm) return;
+    await register(email, password);
+    window.location.href = '/';
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
+      <div className="max-w-md w-full">
+        <div className="text-center mb-8">
+          <div className="bg-gradient-to-r from-blue-500 to-purple-600 p-4 rounded-2xl w-16 h-16 mx-auto mb-6">
+            <Shield className="w-8 h-8 text-white" />
+          </div>
+          <h1 className="text-3xl font-bold text-white mb-2">Регистрация</h1>
+        </div>
+        <div className="bg-slate-800/50 backdrop-blur-sm rounded-2xl p-8 border border-slate-700">
+          <form onSubmit={handleRegister} className="space-y-4">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
+              className="w-full px-4 py-3 rounded-lg bg-slate-900/50 border border-slate-700 text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Пароль"
+              className="w-full px-4 py-3 rounded-lg bg-slate-900/50 border border-slate-700 text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+            <input
+              type="password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              placeholder="Подтвердите пароль"
+              className="w-full px-4 py-3 rounded-lg bg-slate-900/50 border border-slate-700 text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+            <button
+              type="submit"
+              disabled={isFetching}
+              className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-4 px-6 rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl hover:shadow-blue-500/20"
+            >
+              {isFetching ? 'Загрузка...' : 'Зарегистрироваться'}
+            </button>
+          </form>
+          <p className="text-slate-400 text-center mt-4">
+            Уже есть аккаунт? <a href="/" className="text-blue-500 hover:underline">Войти</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- improve OAuth redirect URL builder with query fallback and internal Hanko base
- expose redirect handler parameters and add password login/register endpoints
- add email/password auth and registration page on frontend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898a0620a6883328d927dcb23e45674