### PR TITLE
Fix OAuth flows and k8s readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-HUNKO_USERS_SERVICE_API_URL=http://hanko-public.securelink.svc.cluster.local # URL сервиса Hunko/Hanko
-HUNKO_USERS_SERVICE_API_KEY=changeme              # API ключ сервиса аутентификации
-NEXT_PUBLIC_API_BASE_URL=https://dashboard.zerologsvpn.com    # Базовый адрес API для фронтенда
-NEXT_PUBLIC_HANKO_API_URL=https://dashboard.zerologsvpn.com    # Публичный URL Hanko
-MARZBAN_API_URL=                                  # опционально, URL сервиса Marzban
-MARZBAN_API_KEY=                                  # опционально, ключ доступа Marzban
+HUNKO_USERS_SERVICE_API_URL=http://hanko-public.securelink.svc.cluster.local  # Внутренний URL сервиса Hunko/Hanko
+HUNKO_USERS_SERVICE_API_KEY=changeme                                 # API ключ сервиса аутентификации
+NEXT_PUBLIC_API_BASE_URL=https://dashboard.zerologsvpn.com            # Базовый адрес API (тот же домен, что и фронтенд)
+NEXT_PUBLIC_HANKO_API_URL=https://dashboard.zerologsvpn.com           # Публичный URL Hanko (тот же домен)
+MARZBAN_API_URL=                                                      # опционально, URL сервиса Marzban
+MARZBAN_API_KEY=                                                      # опционально, ключ доступа Marzban

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ npm install
 npm run dev
 ```
 
+Команда `npm run dev` одновременно стартует Hono API и Vite‑сервер на порту `5173`.
+Все запросы фронтенда направляются на тот же домен, поэтому куки сессии сохраняются корректно.
+
 ## Установка
 
 Запустите скрипт `install.sh`, который установит зависимости и подготовит окружение:
@@ -21,10 +24,10 @@ npm run dev
 
 Перед запуском задайте переменные окружения:
 
-- `HUNKO_USERS_SERVICE_API_URL` – адрес сервиса аутентификации Hunko
+- `HUNKO_USERS_SERVICE_API_URL` – внутренний адрес сервиса аутентификации Hunko
 - `HUNKO_USERS_SERVICE_API_KEY` – ключ доступа к сервису аутентификации
-- `NEXT_PUBLIC_API_BASE_URL` – базовый URL API, используется фронтендом
-- `NEXT_PUBLIC_HANKO_API_URL` – публичный URL сервиса Hanko
+- `NEXT_PUBLIC_API_BASE_URL` – базовый URL API (обычно `https://dashboard.zerologsvpn.com`)
+- `NEXT_PUBLIC_HANKO_API_URL` – публичный URL сервиса Hanko (тот же домен, что и фронтенд)
 
 Проект ожидает, что в каталоге `public/` будут размещены локальные иконки и изображения для Open Graph.
 Из-за политики репозитория бинарные файлы не хранятся в Git, поэтому добавьте собственные изображения перед деплоем.
@@ -36,6 +39,9 @@ npm run dev
 ```bash
 kubectl apply -f k8s/deployment.yaml
 ```
+
+В манифесте настроены liveness/readiness‑пробы на `GET /healthz` порта `5173`,
+Service типа `NodePort` пробрасывает порт `30082` на тот же порт контейнера.
 
 ## Как проверить
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -17,3 +17,6 @@
 - Переработан OAuth‑флоу: теперь обмен кода на сессию идёт через `/api/sessions`, куки ставятся с `SameSite=Lax`, а `GET /api/users/me` обращается к Hanko.
 - Формы входа и регистрации используют `credentials: include`, показывают ошибки и спиннеры.
 - Dev-скрипт запускает одновременно API и Vite с помощью `concurrently`.
+- Добавлены алиасы TypeScript `@/worker` и обновлены `tsconfig` файлы.
+- Kubernetes-манифест теперь использует порт 5173 и проверку `/healthz` в liveness/readiness‑пробах.
+- Обновлены `.env.example` и `README.md` с описанием обязательных переменных и новых портов.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: securelink
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: securelink
@@ -16,7 +18,7 @@ spec:
         - name: securelink
           image: securelink:latest
           ports:
-            - containerPort: 3000
+            - containerPort: 5173
           env:
             - name: HUNKO_USERS_SERVICE_API_URL
               value: "http://hunko-users:8000"
@@ -25,15 +27,33 @@ spec:
                 secretKeyRef:
                   name: securelink-secrets
                   key: hunkoApiKey
+            - name: NEXT_PUBLIC_API_BASE_URL
+              value: "https://dashboard.zerologsvpn.com"
+            - name: NEXT_PUBLIC_HANKO_API_URL
+              value: "https://dashboard.zerologsvpn.com"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 5173
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5173
+            initialDelaySeconds: 10
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: securelink
 spec:
+  type: NodePort
   selector:
     app: securelink
   ports:
-    - port: 80
-      targetPort: 3000
+    - port: 5173
+      targetPort: 5173
+      nodePort: 30082
       protocol: TCP

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,7 +9,9 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/worker": ["./src/worker/index.ts"],
+      "@/worker/*": ["./src/worker/*"]
     },
 
     /* Bundler mode */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,13 @@
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" },
     { "path": "./tsconfig.worker.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@/worker": ["src/worker/index.ts"],
+      "@/worker/*": ["src/worker/*"]
+    }
+  }
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -5,7 +5,9 @@
     "types": ["vite/client"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/worker": ["./src/worker/index.ts"],
+      "@/worker/*": ["./src/worker/*"]
     }
   },
   "include": ["src/worker"]


### PR DESCRIPTION
## Summary
- add stable tsconfig aliases and remove invalid self imports
- configure k8s service for port 5173 with health probes and env vars
- document required envs and dev/k8s behaviour

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898b5f8fc108332b685b4a6fd47d053