### PR TITLE
ci: ensure GHCR image name lowercase

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,11 +32,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare image metadata
+        run: |
+          IMAGE_NAME=${GITHUB_REPOSITORY,,}
+          IMAGE_TAG=${GITHUB_SHA,,}
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/securelink:latest
-            ghcr.io/${{ github.repository_owner }}/securelink:sha-${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ env.IMAGE_NAME }}:sha-${{ env.IMAGE_TAG }}

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -71,3 +71,4 @@
 
 - Исправлен CI workflow GitHub Actions: валидный YAML, сборка и смоук‑тест контейнера с Postgres и логами.
 - Упрощён CI: удалён smoke‑test, docker-образ публикуется в GHCR с тегами `latest` и `sha-<commit>` при пуше в `main`.
+- Приведение имени репозитория и тега образа к нижнему регистру в docker‑workflow перед публикацией в GHCR.


### PR DESCRIPTION
## Summary
- force lowercase repository name and tag when publishing Docker images to GHCR
- log this change in development log

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a5d0adec888332854b0e670442be6e